### PR TITLE
Update README.md to include types on extract()

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ import { join } from “$std/path/mod.ts”
 
 async function getPost(slug: string): Promise<Post | null> {
   const text = await Deno.readTextFile(join(‘./posts’, `${slug}.md`));
-  const { attrs, body } = extract(text);
+  const { attrs, body } = extract<{ title: string, published_at: string, snippet: string}>(text);
   return {
     slug,
     title: attrs.title,


### PR DESCRIPTION
Prevents deno-ts 7008 error: "Member 'title' implicitly has an 'any' type.deno-ts(7008)"